### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,8 @@ At first glance it seems that ```watch_for_changes()``` calls itself on every va
 fact it just sends the asynchron request, sets up a callback for the response and then returns.  The
 callback is executed by some thread from the pplx library's thread pool and the callback (in this
 case a small lambda function actually) will call ```watch_for_changes``` again from there.
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/etcd-cpp-api/blob/master/LICENSE.txt).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.